### PR TITLE
BGP negotiated timers. Display BGP timers in CLI.

### DIFF
--- a/schema/openswitch/common/bgp_neighbor.json
+++ b/schema/openswitch/common/bgp_neighbor.json
@@ -387,6 +387,42 @@
           ],
           "group": "/Neighbor Configuration"
         },
+        "negotiated_timers": {
+          "category": "status",
+          "type": {
+            "valueType": "integer",
+            "valueMap": {
+              "holdtime": {
+                "type": {
+                  "type": "integer",
+                  "minInteger": 0,
+                  "maxInteger": 65535
+                },
+                "doc": [
+                  "Per-BGP neighbor negotiated holdtime interval"
+                ],
+                "group": "/Status"
+              },
+              "keepalive": {
+                "type": {
+                  "type": "integer",
+                  "minInteger": 0,
+                  "maxInteger": 65535
+                },
+                "doc": [
+                  "Per-BGP neighbor negotiated keepalive interval"
+                ],
+                "group": "/Status"
+              }
+            },
+            "min": 0,
+            "max": 2
+          },
+          "doc": [
+            "BGP per neighbor negotiated timers - Connect timer/Keep-alive Interval."
+          ],
+          "group": "/Status"
+        },
         "statistics": {
           "category": "statistics",
           "type": {


### PR DESCRIPTION
Tags: fix, dev, Github issue #1

Change-Id: I690bdeee538deea9e4fc5512b3472d80dd07dbeb
Signed-off-by: Ilya Schepin ischepin@mera.ru

CLI command `show ip bgp neighbors` will now show per-neighbor (or per-peer-group) configured BGP timers (keepalive and holdtime) and per-neighbor negotiated timers.  
New status field `negotiated_timers` was added to OVSDB table BGP_Neighbor  
Priority of timer parameters as follows:  
Per-peer-group configured > per-neighbor configured > per-router configured > default values  
Depends on MERAprojects/ops-quagga#24 and MERAprojects/ops-cli#10
